### PR TITLE
Update DockerfileUbuntu.txt

### DIFF
--- a/DockerfileUbuntu.txt
+++ b/DockerfileUbuntu.txt
@@ -6,6 +6,9 @@
 
 FROM ubuntu:16.04
 
+ENV TZ=Europe/Kiev
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 RUN apt-get -y update
 RUN apt-get -y install apache2
 


### PR DESCRIPTION
во время билда образа запрашивает выбор региона. Что бы избежать этого запроса нужно добавить настройку tzdata